### PR TITLE
Correct the gitignore file and add the missing config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ $RECYCLE.BIN/
 *.trx
 *.tsv
 *.txt
-config.json
 alarms/
 .idea/
 TestResults/

--- a/infra/rainmaker-proxy/config.json
+++ b/infra/rainmaker-proxy/config.json
@@ -1,0 +1,20 @@
+[
+    {
+        "project": "Orleans", 
+        "project_test_path": "orleans\\test\\Extensions\\TesterAzureUtils",
+        "project_path_root": "\\Users\\",
+        "rainmaker_path": "cloudtest\\infra\\rainmaker-proxy",
+        "skip": false,
+        "policy": "vanilla_real",
+        "policies(for doc purpose)": ["vanilla","vanilla_real"],
+        "test_dll": "%HOMEDRIVE%%HOMEPATH%\\orleans\\test\\Extensions\\TesterAzureUtils\\bin\\Debug\\net7.0\\Tester.AzureUtils.dll",
+        "full_test": false,
+        "partial_test": ["Tester.AzureUtils.AzureQueueDataManagerTests.AQ_Standalone_1",
+                        "Tester.AzureUtils.TimerTests.ReminderTests_AzureTable.Rem_Azure_Wrong_Grain",
+                        "Tester.AzureUtils.Streaming.AQStreamingTests.AQ_01_OneProducerGrainOneConsumerGrain",
+                        "UnitTests.Streaming.Reliability.StreamReliabilityTests.AQ_StreamRel_SiloRestarts_Consumer",
+                        "Tester.AzureUtils.AzureTableGrainDirectoryTests.LookupNotFound"],
+        "other_usually_used_tests(for doc purpose)": ["Tester.AzureUtils.TimerTests.ReminderTests_AzureTable.Rem_Azure_Wrong_Grain","Tester.AzureUtils.Streaming.AQStreamingTests.AQ_01_OneProducerGrainOneConsumerGrain","UnitTests.Streaming.Reliability.StreamReliabilityTests.AQ_StreamRel_SiloRestarts_Consumer", "Tester.AzureUtils.AzureQueueDataManagerTests.AQ_Standalone_1", "Tester.AzureUtils.AzureTableGrainDirectoryTests.LookupNotFound"]
+
+    }
+]


### PR DESCRIPTION
#### What is this PR?
This PR adds the missing config.json file (mainly copy from [template-config.json](https://github.com/xlab-uiuc/cloudtest/blob/main/infra/rainmaker-proxy/template-config.json) but update the path and dotnet version). And removes this file from the [.gitignore](https://github.com/xlab-uiuc/cloudtest/blob/main/.gitignore) file.